### PR TITLE
Improve Arch port scripts and wallpaper pipeline

### DIFF
--- a/arch-port/.config/quickshell/mycael/colors-fallback.js
+++ b/arch-port/.config/quickshell/mycael/colors-fallback.js
@@ -1,3 +1,5 @@
+// Default colors when Matugen has not yet generated a scheme
+.pragma library
 var theme = {
     primary: "#6750A4",
     onPrimary: "#FFFFFF",

--- a/arch-port/.config/quickshell/mycael/colors-loader.qml
+++ b/arch-port/.config/quickshell/mycael/colors-loader.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick
-import Quickshell.Io
+import QtQuick 2.15
+import Quickshell.Io 1.0
 
 QtObject {
     id: root

--- a/arch-port/.local/bin/mycael-matugen-apply
+++ b/arch-port/.local/bin/mycael-matugen-apply
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # Generate theme from wallpaper using Matugen and reload Mycael
 set -Eeuo pipefail
+IFS=$'\n\t'
 
 usage() {
-  echo "Usage: mycael-matugen-apply [WALLPAPER]" >&2
-  exit 1
+	echo "Usage: mycael-matugen-apply [WALLPAPER]" >&2
+	exit 1
 }
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
-  usage
+	usage
 fi
 
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/mycael"
@@ -20,20 +21,26 @@ LOG_FILE="$LOG_DIR/matugen.log"
 log() { printf '%s\n' "$*" >>"$LOG_FILE"; }
 
 get_wallpaper() {
-  if [[ -n ${1:-} ]]; then printf '%s\n' "$1"; return; fi
-  if command -v swww >/dev/null 2>&1; then
-    swww query 2>/dev/null | grep -oP 'image: \K.*' | head -n1 && return
-  fi
-  if command -v hyprctl >/dev/null 2>&1; then
-    hyprctl hyprpaper list 2>/dev/null | awk '{print $2}' | head -n1 && return
-  fi
-  if [[ -f "$CONFIG_DIR/config/wallpaper.conf" ]]; then
-    head -n1 "$CONFIG_DIR/config/wallpaper.conf" && return
-  fi
-  return 1
+	if [[ -n ${1:-} ]]; then
+		printf '%s\n' "$1"
+		return
+	fi
+	if command -v swww >/dev/null 2>&1; then
+		swww query 2>/dev/null | grep -oP 'image: \K.*' | head -n1 && return
+	fi
+	if command -v hyprctl >/dev/null 2>&1; then
+		hyprctl hyprpaper list 2>/dev/null | awk '{print $2}' | head -n1 && return
+	fi
+	if [[ -f "$CONFIG_DIR/config/wallpaper.conf" ]]; then
+		head -n1 "$CONFIG_DIR/config/wallpaper.conf" && return
+	fi
+	return 1
 }
 
-wallpaper=$(get_wallpaper "$1") || { log "Could not determine wallpaper"; exit 1; }
+wallpaper=$(get_wallpaper "$1") || {
+	log "Could not determine wallpaper"
+	exit 1
+}
 
 log "Generating scheme for $wallpaper"
 
@@ -41,11 +48,14 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 if ! matugen image "$wallpaper" --config "$MATUGEN_CFG" --prefix "$tmpdir" >>"$LOG_FILE" 2>&1; then
-  log "matugen failed"; exit 1; fi
+	log "matugen failed"
+	exit 1
+fi
 
-install -Dm644 "$tmpdir/quickshell/mycael/colors/colors-generated.js" "$CONFIG_DIR/colors/colors-generated.js"
-install -Dm644 "$tmpdir/quickshell/mycael/colors/qtcolors.conf" "$CONFIG_DIR/colors/qtcolors.conf"
+mkdir -p "$CONFIG_DIR/colors"
+mv "$tmpdir/quickshell/mycael/colors/colors-generated.js" "$CONFIG_DIR/colors/colors-generated.js"
+mv "$tmpdir/quickshell/mycael/colors/qtcolors.conf" "$CONFIG_DIR/colors/qtcolors.conf"
 
 if systemctl --user is-active --quiet mycael.service; then
-  systemctl --user restart mycael.service >>"$LOG_FILE" 2>&1 || true
+	systemctl --user restart mycael.service >>"$LOG_FILE" 2>&1 || true
 fi

--- a/arch-port/.local/bin/mycael-run
+++ b/arch-port/.local/bin/mycael-run
@@ -1,30 +1,31 @@
 #!/usr/bin/env bash
 # Wrapper to launch the Mycael Quickshell session
 set -Eeuo pipefail
+IFS=$'\n\t'
 
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/mycael"
 LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/mycael/logs"
 mkdir -p "$LOG_DIR"
 
-if [[ "$#" -gt 0 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
-  echo "Usage: mycael-run [quickshell args...]" >&2
-  exit 0
+if [[ $# -gt 0 && ($1 == "-h" || $1 == "--help") ]]; then
+	echo "Usage: mycael-run [quickshell args...]" >&2
+	exit 0
 fi
 
 ENV_FILE="$CONFIG_DIR/.env"
-if [[ -f "$ENV_FILE" ]]; then
-  set -a
-  # shellcheck disable=SC1090
-  source "$ENV_FILE"
-  set +a
+if [[ -f $ENV_FILE ]]; then
+	set -a
+	# shellcheck disable=SC1090
+	source "$ENV_FILE"
+	set +a
 fi
 
 LOG_FILE="$LOG_DIR/mycael.log"
-: > "$LOG_FILE"
+: >"$LOG_FILE"
 
 BIN="qs"
 if ! command -v "$BIN" >/dev/null 2>&1; then
-  BIN="quickshell"
+	BIN="quickshell"
 fi
 
 exec "$BIN" "$CONFIG_DIR/mycael.qml" "$@" >>"$LOG_FILE" 2>&1

--- a/arch-port/.local/bin/mycael-wallpaper-set
+++ b/arch-port/.local/bin/mycael-wallpaper-set
@@ -1,20 +1,31 @@
 #!/usr/bin/env bash
 # Set wallpaper using swww or hyprpaper and regenerate theme
 set -Eeuo pipefail
+IFS=$'\n\t'
 
-usage() { echo "Usage: mycael-wallpaper-set IMAGE" >&2; exit 1; }
+usage() {
+	echo "Usage: mycael-wallpaper-set IMAGE" >&2
+	exit 1
+}
 
 img="${1:-}"
-[[ -z "$img" ]] && usage
+[[ -z $img ]] && usage
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/mycael/config"
+mkdir -p "$CONFIG_DIR"
+tmpfile=$(mktemp)
+printf '%s\n' "$img" >"$tmpfile"
+mv "$tmpfile" "$CONFIG_DIR/wallpaper.conf"
 
 if command -v swww >/dev/null 2>&1; then
-  swww img "$img"
+	swww img "$img"
 elif command -v hyprctl >/dev/null 2>&1; then
-  hyprctl hyprpaper preload "$img"
-  hyprctl hyprpaper wallpaper ,"$img"
+	hyprctl hyprpaper preload "$img"
+	hyprctl hyprpaper wallpaper ,"$img"
 else
-  echo "No wallpaper setter found" >&2
-  exit 1
+	echo "No wallpaper setter found" >&2
+	exit 1
 fi
 
-systemctl --user start mycael-matugen@"$img"
+escaped=$(systemd-escape -- "$img")
+systemctl --user start "mycael-matugen@${escaped}.service"

--- a/arch-port/scripts/check-deps.sh
+++ b/arch-port/scripts/check-deps.sh
@@ -1,55 +1,57 @@
 #!/usr/bin/env bash
 # Verify runtime dependencies for Mycael
 set -Eeuo pipefail
+IFS=$'\n\t'
 
 pass=true
 check_bin() {
-  local b="$1"; shift
-  if command -v "$b" >/dev/null 2>&1; then
-    echo "Found: $b"
-  else
-    echo "Missing: $b $*"
-    pass=false
-  fi
+	local b="$1"
+	shift
+	if command -v "$b" >/dev/null 2>&1; then
+		echo "Found: $b"
+	else
+		echo "Missing: $b $*"
+		pass=false
+	fi
 }
 
 echo "Checking required binaries..."
 for bin in qs matugen hyprctl jq inotifywait wl-copy; do
-  check_bin "$bin"
+	check_bin "$bin"
 done
 
 if command -v swww >/dev/null 2>&1; then
-  echo "Found: swww"
+	echo "Found: swww"
 elif command -v hyprctl >/dev/null 2>&1 && hyprctl hyprpaper list >/dev/null 2>&1; then
-  echo "Found: hyprpaper"
+	echo "Found: hyprpaper"
 else
-  echo "Missing: swww or hyprpaper"
-  pass=false
+	echo "Missing: swww or hyprpaper"
+	pass=false
 fi
 
 for opt in playerctl grim slurp; do
-  if command -v "$opt" >/dev/null 2>&1; then
-    echo "Found optional: $opt"
-  else
-    echo "Optional missing: $opt"
-  fi
- done
+	if command -v "$opt" >/dev/null 2>&1; then
+		echo "Found optional: $opt"
+	else
+		echo "Optional missing: $opt"
+	fi
+done
 
-if [[ "${XDG_SESSION_TYPE:-}" != "wayland" ]]; then
-  echo "Warning: not a Wayland session"
-  pass=false
+if [[ ${XDG_SESSION_TYPE:-} != "wayland" ]]; then
+	echo "Warning: not a Wayland session"
+	pass=false
 else
-  echo "Wayland session detected"
+	echo "Wayland session detected"
 fi
 
 if $pass; then
-  echo "All dependencies satisfied"
+	echo "All dependencies satisfied"
 else
-  cat <<PAC
+	cat <<PAC
 Install missing packages with:
   sudo pacman -S --needed hyprland jq wl-clipboard inotify-tools swww grim slurp playerctl pipewire wireplumber noto-fonts noto-fonts-emoji
 AUR (yay):
   yay -S quickshell-git matugen-bin
 PAC
-  exit 1
+	exit 1
 fi

--- a/arch-port/scripts/link.sh
+++ b/arch-port/scripts/link.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Idempotently symlink Mycael files into \$HOME
 set -Eeuo pipefail
+IFS=$'\n\t'
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 ARCH_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
@@ -8,15 +9,15 @@ STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 BACKUP_DIR="$STATE_HOME/mycael-backup-$(date +%s)"
 
 link_one() {
-  local rel="$1" src="$ARCH_ROOT/$1" dest="$HOME/$1"
-  mkdir -p "$(dirname "$dest")"
-  if [[ -e "$dest" && ! -L "$dest" ]]; then
-    mkdir -p "$BACKUP_DIR/$(dirname "$rel")"
-    mv "$dest" "$BACKUP_DIR/$rel"
-    echo "Backup: $dest -> $BACKUP_DIR/$rel"
-  fi
-  ln -sfn "$src" "$dest"
-  printf '%s -> %s\n' "$dest" "$src"
+	local rel="$1" src="$ARCH_ROOT/$1" dest="$HOME/$1"
+	mkdir -p "$(dirname "$dest")"
+	if [[ -e $dest && ! -L $dest ]]; then
+		mkdir -p "$BACKUP_DIR/$(dirname "$rel")"
+		mv "$dest" "$BACKUP_DIR/$rel"
+		echo "Backup: $dest -> $BACKUP_DIR/$rel"
+	fi
+	ln -sfn "$src" "$dest"
+	printf '%s -> %s\n' "$dest" "$src"
 }
 
 link_one .config/quickshell/mycael

--- a/arch-port/scripts/selftest.sh
+++ b/arch-port/scripts/selftest.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Basic self-test for Mycael scripts
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+"$SCRIPT_DIR/check-deps.sh" || true
+
+tmpimg=$(mktemp)
+trap 'rm -f "$tmpimg"' EXIT
+printf '\211PNG\r\n\032\n' >"$tmpimg" # dummy header
+if "$ROOT/.local/bin/mycael-wallpaper-set" "$tmpimg" 2>/tmp/wall.log; then
+	echo "wallpaper-set executed"
+else
+	echo "wallpaper-set failed (expected if no wallpaper tool)"
+fi

--- a/arch-port/scripts/unlink.sh
+++ b/arch-port/scripts/unlink.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 # Remove links created by link.sh
 set -Eeuo pipefail
+IFS=$'\n\t'
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 ARCH_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 
 remove_one() {
-  local rel="$1" src="$ARCH_ROOT/$1" dest="$HOME/$1"
-  if [[ -L "$dest" && "$(readlink -f "$dest")" == "$src" ]]; then
-    rm "$dest"
-    echo "Removed $dest"
-  else
-    echo "Skipping $dest"
-  fi
+	local src="$ARCH_ROOT/$1" dest="$HOME/$1"
+	if [[ -L $dest && "$(readlink -f "$dest")" == "$src" ]]; then
+		rm "$dest"
+		echo "Removed $dest"
+	else
+		echo "Skipping $dest"
+	fi
 }
 
 remove_one .config/quickshell/mycael


### PR DESCRIPTION
## Summary
- harden Arch port shell scripts with strict IFS handling and formatting
- make matugen apply and wallpaper utilities robust to spaces and atomic writes
- expose fallback colors as a library and tighten QML imports
- add simple self-test harness

## Testing
- `shellcheck arch-port/scripts/check-deps.sh arch-port/scripts/link.sh arch-port/scripts/unlink.sh arch-port/scripts/selftest.sh arch-port/.local/bin/mycael-run arch-port/.local/bin/mycael-matugen-apply arch-port/.local/bin/mycael-wallpaper-set`
- `shfmt -d -s arch-port/scripts/check-deps.sh arch-port/scripts/link.sh arch-port/scripts/unlink.sh arch-port/scripts/selftest.sh arch-port/.local/bin/mycael-run arch-port/.local/bin/mycael-matugen-apply arch-port/.local/bin/mycael-wallpaper-set`
- `/usr/lib/qt6/bin/qmllint arch-port/.config/quickshell/mycael/colors-loader.qml` (warnings expected: missing Qt/Quickshell modules in container)
- `jq . arch-port/.config/quickshell/mycael/config.json`
- `arch-port/scripts/selftest.sh`

------
https://chatgpt.com/codex/tasks/task_e_689ec0fe212083218837ca5b53f4464d